### PR TITLE
Fix for DataLoader not accepting num_workers

### DIFF
--- a/thre3d_atom/modules/trainers.py
+++ b/thre3d_atom/modules/trainers.py
@@ -520,7 +520,7 @@ def _make_dataloader_from_dataset(
         batch_size=batch_size,
         shuffle=True,
         drop_last=True,
-        num_workers=0 if dataset.cached_data_mode else dataset,
+        num_workers=num_workers,
         pin_memory=not dataset.cached_data_mode and num_workers > 0,
         prefetch_factor=num_workers
         if not dataset.cached_data_mode and num_workers > 0

--- a/train_sh_based_voxel_grid_with_posed_images.py
+++ b/train_sh_based_voxel_grid_with_posed_images.py
@@ -25,7 +25,7 @@ cudnn.benchmark = True
 # Also set torch's multiprocessing start method to spawn
 # refer -> https://github.com/pytorch/pytorch/issues/40403
 # for more information. Some stupid PyTorch stuff to take care of
-torch.multiprocessing.set_start_method("spawn")
+torch.multiprocessing.set_start_method("spawn", force=True)
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 


### PR DESCRIPTION
What does this PR do? 

---- 
This PR resolves an issue where the num_workers variable is not accepted by DataLoader and fixes the 'RuntimeError: context has already been set' by adding the force option to torch.multiprocessing.set_start_method.